### PR TITLE
update links for buttons

### DIFF
--- a/src/components/homepage/Interest.js
+++ b/src/components/homepage/Interest.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { createStyles, Group, Title, Text, TextInput, Button, Container, Center } from '@mantine/core';
-import { Book, QuestionMark, BrandSlack, Calendar, BrandGithub } from 'tabler-icons-react';
+import { Book, QuestionMark, BrandSlack, Mail, BrandGithub } from 'tabler-icons-react';
 
 const useStyles = createStyles((theme) => ({
   wrapper: {
@@ -119,9 +119,11 @@ export function InterestedField() {
           <Button leftIcon={<Book />} className={classes.control} size="lg" variant="default" color="gray">
             Data Science Learning Pathway
           </Button>
-          <Button leftIcon={<QuestionMark />} className={classes.control} size="lg">
-            Operate First Support
-          </Button>
+          <a href="https://github.com/operate-first/support">
+            <Button leftIcon={<QuestionMark />} className={classes.control} size="lg">
+              Operate First Support
+            </Button>
+          </a>
         </div>
         <Title align="center" style={{ color: 'white', marginTop: 40 }} className={classes.title}>Want to get involved?</Title>
         <Container p={0} size={600}>
@@ -130,15 +132,21 @@ export function InterestedField() {
           </Text>
         </Container>
         <Group style={{ marginTop: "20px" }}>
-          <Button leftIcon={<BrandGithub />} className={classes.btncontrol} size="lg" variant="default" color="gray">
-            Our GitHub
-          </Button>
-          <Button leftIcon={<BrandSlack />} className={classes.btncontrol} size="lg" variant="default" color="gray">
-            Join our Slack
-          </Button>
-          <Button leftIcon={<Calendar />} className={classes.btncontrol} size="lg">
-            Join our calender
-          </Button>
+          <a href="https://github.com/operate-first">
+            <Button leftIcon={<BrandGithub />} className={classes.btncontrol} size="lg" variant="default" color="gray">
+              Our GitHub
+            </Button>
+          </a>
+          <a href="https://join.slack.com/t/operatefirst/shared_invite/zt-o2gn4wn8-O39g7sthTAuPCvaCNRnLww">
+            <Button leftIcon={<BrandSlack />} className={classes.btncontrol} size="lg" variant="default" color="gray">
+              Join our Slack
+            </Button>
+          </a>
+          <a href="https://lists.operate-first.cloud/admin/lists/community.lists.operate-first.cloud/">
+            <Button leftIcon={<Mail />} className={classes.btncontrol} size="lg">
+              Join our Mailing list
+            </Button>
+          </a>
         </Group>
       </div>
     </Center>

--- a/src/components/nav-tabs/CommunityCloud.js
+++ b/src/components/nav-tabs/CommunityCloud.js
@@ -18,8 +18,12 @@ export function CommunityCloudContent() {
             </List>
             <Title order={2} my="md">Community Cloud Resources</Title>
             <Group style={{ marginBottom: 50 }}>
-                <Button leftIcon={<Book />} color="dark">GitOps Docs</Button>
-                <Button leftIcon={<Cloud />} color="dark">Open community cloud</Button>
+                <a href="https://www.operate-first.cloud/apps/content/README.html">
+                    <Button leftIcon={<Book />} color="dark">GitOps Docs</Button>
+                </a>
+                <a href="https://www.operate-first.cloud/community/README.html">
+                    <Button leftIcon={<Cloud />} color="dark">Open community cloud</Button>
+                </a>
                 <Button leftIcon={<Database />} color="dark">Data Science</Button>
             </Group>
 

--- a/src/components/nav-tabs/CommunityPage.js
+++ b/src/components/nav-tabs/CommunityPage.js
@@ -21,7 +21,9 @@ export function CommunityContent() {
             <Title order={2} my="md">Community Resources</Title>
             <Group style={{ marginBottom: 50 }}>
                 <Button color="dark">Our Environment</Button>
-                <Button color="dark">Open community cloud</Button>
+                <a href="https://www.operate-first.cloud/community/README.html">
+                    <Button color="dark">Open community cloud</Button>
+                </a>
                 <Button color="dark">SRE Community of Practice</Button>
             </Group>
         </Container>


### PR DESCRIPTION
Added links for the following buttons :

![image](https://user-images.githubusercontent.com/26301643/167207613-d17778ea-8cd6-47c0-9de1-950172c7d4b1.png)


Added links for community cloud, gitops doc, support.


For issues : https://github.com/open-services-group/community/issues/163, https://github.com/open-services-group/community/issues/164 , https://github.com/open-services-group/community/issues/165, https://github.com/open-services-group/community/issues/166, https://github.com/open-services-group/community/issues/167