### PR TITLE
Navigation pages created

### DIFF
--- a/src/components/homepage/Navbar.js
+++ b/src/components/homepage/Navbar.js
@@ -76,8 +76,7 @@ const useStyles = createStyles((theme) => ({
 
 export function Nav({ links }) {
   const [opened, toggleOpened] = useBooleanToggle(false);
-  const [active, setActive] = useState(links[0].link);
-  const { classes, cx } = useStyles();
+  const { classes} = useStyles();
 
   const items = links.map((link) => (
     <Link
@@ -96,10 +95,11 @@ export function Nav({ links }) {
   return (
     <Header height={HEADER_HEIGHT} className={classes.root}>
       <Container className={classes.header}>
-        <img src={icon} width="150px" alt="opf-logo" />
+        <Link to="/">
+          <img src={icon} width="150px" alt="opf-logo" />
+        </Link>
         <Group spacing={7} className={classes.links}>
-        {items}
-
+          {items}
           <a href="https://github.com/operate-first" target="_blank" rel="noreferrer">
             <BrandGithub color="white" />
           </a>

--- a/src/components/nav-tabs/AboutPage.js
+++ b/src/components/nav-tabs/AboutPage.js
@@ -1,0 +1,11 @@
+import { Container, Text, Title } from '@mantine/core';
+import React from 'react';
+
+export function AboutContent() {
+    return (
+        <Container>
+            <Title order={2} my="md">Op1st Community Cloud</Title>
+            <Text>Content here to be finalized</Text>
+        </Container>
+    )
+}

--- a/src/components/nav-tabs/CommunityCloud.js
+++ b/src/components/nav-tabs/CommunityCloud.js
@@ -1,0 +1,29 @@
+import { Button, Container, Text, Title, Group, List } from '@mantine/core';
+import React from 'react';
+import { Book, Cloud, Database } from 'tabler-icons-react';
+
+export function CommunityCloudContent() {
+    return (
+        <Container>
+            <Title order={2} my="md">Op1st Community Cloud</Title>
+            <Text>
+                The Operate First community makes use of the GitHub open source DevOps platform and integrated community management tools. The links here direct you to resources within that community space at GitHub:
+            </Text>
+            <List my="md">
+                <List.Item>Data Science Apps</List.Item>
+                <List.Item>Open Source Developer content</List.Item>
+                <List.Item>SRE Operations</List.Item>
+                <List.Item>Blueprints</List.Item>
+                <List.Item>Support</List.Item>
+            </List>
+            <Title order={2} my="md">Community Cloud Resources</Title>
+            <Group style={{ marginBottom: 50 }}>
+                <Button leftIcon={<Book />} color="dark">GitOps Docs</Button>
+                <Button leftIcon={<Cloud />} color="dark">Open community cloud</Button>
+                <Button leftIcon={<Database />} color="dark">Data Science</Button>
+            </Group>
+
+
+        </Container>
+    )
+}

--- a/src/components/nav-tabs/CommunityPage.js
+++ b/src/components/nav-tabs/CommunityPage.js
@@ -1,0 +1,29 @@
+import { Button, Container, Text, Title, Group } from '@mantine/core';
+import React from 'react';
+
+export function CommunityContent() {
+    return (
+        <Container>
+            <Title order={2} my="md">Get involved in Operate First</Title>
+            <Text>
+                The Operate First community makes use of the GitHub open source DevOps platform and integrated community management tools. The links here direct you to resources within that community space at GitHub:
+            </Text>
+            <Title order={2} my="md">About the community</Title>
+            <Text>Code of Conduct</Text>
+            <Text>Community Handbook</Text>
+            <Text>Special Interest Groups</Text>
+            <Text>Participating Projects</Text>
+            <Title order={2} my="md">Getting involved</Title>
+            <Text>Mailing List</Text>
+            <Text>Slack team chat</Text>
+            <Title order={2} my="md">Operate First Blog</Title>
+            <Text>For complete details, read the <a href="#">Operate First Community Manifesto</a></Text>
+            <Title order={2} my="md">Community Resources</Title>
+            <Group style={{ marginBottom: 50 }}>
+                <Button color="dark">Our Environment</Button>
+                <Button color="dark">Open community cloud</Button>
+                <Button color="dark">SRE Community of Practice</Button>
+            </Group>
+        </Container>
+    )
+}

--- a/src/components/nav-tabs/DocTraining.js
+++ b/src/components/nav-tabs/DocTraining.js
@@ -1,0 +1,22 @@
+import { Container, Text, Title } from '@mantine/core';
+import React from 'react';
+
+export function DocTrainingContent() {
+    return (
+        <Container>
+            <Title order={2} my="md">Operate First Documentation and Training</Title>
+            <Text>
+                Unified Operate First Glossary of Terms
+            </Text>
+            <Title order={2} my="md">Developer Documents</Title>
+            <Text>Quick Start Guide for Open Source Developers</Text>
+            <Title order={2} my="md">Community Cloud Users Documents</Title>
+            <Text>Document Name</Text>
+            <Text>Document Name</Text>
+            <Title order={2} my="md">Data Science Documents</Title>
+            <Text>Docunment Name</Text>
+            <Title order={2} my="md">Training Courses</Title>
+            <Text>Course Name</Text>
+        </Container>
+    )
+}

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -1,28 +1,25 @@
 import * as React from "react";
 // Component imports
-import { HomeContent } from "../components/homepage/HomePage";
-import { AboutFeatures } from "../components/homepage/About";
-import { InterestedField } from "../components/homepage/Interest";
-import { FaqSimple } from "../components/homepage/Faq";
 import { Nav } from "../components/homepage/Navbar";
 import { Footer } from "../components/homepage/Footer";
+import { AboutContent } from "../components/nav-tabs/AboutPage";
 
-const IndexPage = () => {
+const AboutPage = () => {
   const navItems = [
     {
       "link": "/about",
       "label": "Our Purpose"
     },
     {
-      "link": "/pricing",
+      "link": "/community",
       "label": "Community"
     },
     {
-      "link": "/learn",
+      "link": "/docs-training",
       "label": "Docs & Training"
     },
     {
-      "link": "/community",
+      "link": "/community-cloud",
       "label": "Op1st Community Cloud"
     }
   ]
@@ -55,13 +52,10 @@ const IndexPage = () => {
       }
     `}</style>
       <Nav links={navItems} />
-      <HomeContent />
-      <AboutFeatures />
-      <InterestedField />
-      <FaqSimple />
-      <Footer links={footerItems}/>
+      <AboutContent />
+      <Footer links={footerItems} />
     </main>
   )
 }
 
-export default IndexPage;
+export default AboutPage;

--- a/src/pages/community-cloud.js
+++ b/src/pages/community-cloud.js
@@ -1,0 +1,61 @@
+import * as React from "react";
+// Component imports
+import { Nav } from "../components/homepage/Navbar";
+import { Footer } from "../components/homepage/Footer";
+import { CommunityCloudContent } from "../components/nav-tabs/CommunityCloud";
+
+const CommunityCloudPage = () => {
+    const navItems = [
+        {
+            "link": "/about",
+            "label": "Our Purpose"
+        },
+        {
+            "link": "/community",
+            "label": "Community"
+        },
+        {
+            "link": "/docs-training",
+            "label": "Docs & Training"
+        },
+        {
+            "link": "/community-cloud",
+            "label": "Op1st Community Cloud"
+        }
+    ]
+
+    const footerItems = [
+        {
+            "link": "https://www.redhat.com/en/about/privacy-policy",
+            "label": "Privacy statement"
+        },
+        {
+            "link": "https://www.redhat.com/en/about/terms-use",
+            "label": "Terms of use"
+        },
+        {
+            "link": "https://www.redhat.com/en/about/all-policies-guidelines",
+            "label": "Policies and guidelines"
+        },
+        {
+            "link": "https://openinfra.dev/legal/code-of-conduct",
+            "label": "Code of Conduct"
+        }
+    ]
+
+    return (
+        <main>
+            <style jsx global>{`
+      body {
+        margin: 0px;
+        padding: 0px;
+      }
+    `}</style>
+            <Nav links={navItems} />
+            <CommunityCloudContent />
+            <Footer links={footerItems} />
+        </main>
+    )
+}
+
+export default CommunityCloudPage;

--- a/src/pages/community.js
+++ b/src/pages/community.js
@@ -1,0 +1,61 @@
+import * as React from "react";
+// Component imports
+import { Nav } from "../components/homepage/Navbar";
+import { Footer } from "../components/homepage/Footer";
+import { CommunityContent } from "../components/nav-tabs/CommunityPage";
+
+const AboutPage = () => {
+    const navItems = [
+        {
+            "link": "/about",
+            "label": "Our Purpose"
+        },
+        {
+            "link": "/community",
+            "label": "Community"
+        },
+        {
+            "link": "/docs-training",
+            "label": "Docs & Training"
+        },
+        {
+            "link": "/community-cloud",
+            "label": "Op1st Community Cloud"
+        }
+    ]
+
+    const footerItems = [
+        {
+            "link": "https://www.redhat.com/en/about/privacy-policy",
+            "label": "Privacy statement"
+        },
+        {
+            "link": "https://www.redhat.com/en/about/terms-use",
+            "label": "Terms of use"
+        },
+        {
+            "link": "https://www.redhat.com/en/about/all-policies-guidelines",
+            "label": "Policies and guidelines"
+        },
+        {
+            "link": "https://openinfra.dev/legal/code-of-conduct",
+            "label": "Code of Conduct"
+        }
+    ]
+
+    return (
+        <main>
+            <style jsx global>{`
+      body {
+        margin: 0px;
+        padding: 0px;
+      }
+    `}</style>
+            <Nav links={navItems} />
+            <CommunityContent />
+            <Footer links={footerItems} />
+        </main>
+    )
+}
+
+export default AboutPage;

--- a/src/pages/community.js
+++ b/src/pages/community.js
@@ -4,7 +4,7 @@ import { Nav } from "../components/homepage/Navbar";
 import { Footer } from "../components/homepage/Footer";
 import { CommunityContent } from "../components/nav-tabs/CommunityPage";
 
-const AboutPage = () => {
+const CommunityPage = () => {
     const navItems = [
         {
             "link": "/about",
@@ -58,4 +58,4 @@ const AboutPage = () => {
     )
 }
 
-export default AboutPage;
+export default CommunityPage;

--- a/src/pages/docs-training.js
+++ b/src/pages/docs-training.js
@@ -1,0 +1,61 @@
+import * as React from "react";
+// Component imports
+import { Nav } from "../components/homepage/Navbar";
+import { Footer } from "../components/homepage/Footer";
+import { DocTrainingContent } from "../components/nav-tabs/DocTraining";
+
+const DocsTrainingPage = () => {
+    const navItems = [
+        {
+            "link": "/about",
+            "label": "Our Purpose"
+        },
+        {
+            "link": "/community",
+            "label": "Community"
+        },
+        {
+            "link": "/docs-training",
+            "label": "Docs & Training"
+        },
+        {
+            "link": "/community-cloud",
+            "label": "Op1st Community Cloud"
+        }
+    ]
+
+    const footerItems = [
+        {
+            "link": "https://www.redhat.com/en/about/privacy-policy",
+            "label": "Privacy statement"
+        },
+        {
+            "link": "https://www.redhat.com/en/about/terms-use",
+            "label": "Terms of use"
+        },
+        {
+            "link": "https://www.redhat.com/en/about/all-policies-guidelines",
+            "label": "Policies and guidelines"
+        },
+        {
+            "link": "https://openinfra.dev/legal/code-of-conduct",
+            "label": "Code of Conduct"
+        }
+    ]
+
+    return (
+        <main>
+            <style jsx global>{`
+      body {
+        margin: 0px;
+        padding: 0px;
+      }
+    `}</style>
+            <Nav links={navItems} />
+            <DocTrainingContent />
+            <Footer links={footerItems} />
+        </main>
+    )
+}
+
+export default DocsTrainingPage;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -14,15 +14,15 @@ const IndexPage = () => {
       "label": "Our Purpose"
     },
     {
-      "link": "/pricing",
+      "link": "/community",
       "label": "Community"
     },
     {
-      "link": "/learn",
+      "link": "/docs-training",
       "label": "Docs & Training"
     },
     {
-      "link": "/community",
+      "link": "/community-cloud",
       "label": "Op1st Community Cloud"
     }
   ]


### PR DESCRIPTION
### Description
With this commit `Our Purpose, Community, Docs & Training, Op1st Community Cloud` each have their own respective pages along with a component for each. These pages come barebones with simple Mantine components (Buttons, Text, Title, etc)

**Next steps:**
The next steps after this PR is to come up with mock designs for how we would like each page to look and what content to have. Along with how should we link each Jupyter book

**Misc:**
Added `Link` component to `homepage/Navbar.js` so now the Operate First logo is clickable to the home page.

### Preview:
![image](https://user-images.githubusercontent.com/68972382/167014132-f3ee4a47-da42-4895-a121-bc98d450671c.png)
