### PR TITLE
Prop-type errors and jsx errors fixed

### DIFF
--- a/src/components/homepage/About.js
+++ b/src/components/homepage/About.js
@@ -65,7 +65,7 @@ const mockdata = [
 ];
 
 Feature.propTypes = {
-  icon: PropTypes.object,
+  icon: PropTypes.func,
   title: PropTypes.string,
   description: PropTypes.string,
   className: PropTypes.object,

--- a/src/components/homepage/Footer.js
+++ b/src/components/homepage/Footer.js
@@ -56,5 +56,5 @@ export function Footer({ links }) {
 }
 
 Footer.propTypes = {
-    links: PropTypes.object,
+    links: PropTypes.array,
 }

--- a/src/components/homepage/Navbar.js
+++ b/src/components/homepage/Navbar.js
@@ -149,5 +149,5 @@ export function Nav({ links }) {
 }
 
 Nav.propTypes = {
-  links: PropTypes.object,
+  links: PropTypes.array,
 }

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -24,7 +24,6 @@ const codeStyles = {
   borderRadius: 4,
 }
 
-// markup
 const NotFoundPage = () => {
   return (
     <main style={pageStyles}>

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -1,4 +1,5 @@
 import * as React from "react";
+import '../pages/style.css';
 // Component imports
 import { Nav } from "../components/homepage/Navbar";
 import { Footer } from "../components/homepage/Footer";
@@ -45,12 +46,6 @@ const AboutPage = () => {
 
   return (
     <main>
-      <style jsx global>{`
-      body {
-        margin: 0px;
-        padding: 0px;
-      }
-    `}</style>
       <Nav links={navItems} />
       <AboutContent />
       <Footer links={footerItems} />

--- a/src/pages/action.js
+++ b/src/pages/action.js
@@ -1,4 +1,5 @@
 import * as React from "react";
+import '../pages/style.css';
 // Component imports
 import { Nav } from "../components/homepage/Navbar";
 import { Footer } from "../components/homepage/Footer";
@@ -45,12 +46,6 @@ const ActionPage = () => {
 
   return (
     <main>
-      <style jsx global>{`
-      body {
-        margin: 0px;
-        padding: 0px;
-      }
-    `}</style>
       <Nav links={navItems} />
       <ActionContent />
       <Footer links={footerItems} />

--- a/src/pages/community-cloud.js
+++ b/src/pages/community-cloud.js
@@ -1,4 +1,5 @@
 import * as React from "react";
+import '../pages/style.css';
 // Component imports
 import { Nav } from "../components/homepage/Navbar";
 import { Footer } from "../components/homepage/Footer";
@@ -45,12 +46,6 @@ const CommunityCloudPage = () => {
 
     return (
         <main>
-            <style jsx global>{`
-      body {
-        margin: 0px;
-        padding: 0px;
-      }
-    `}</style>
             <Nav links={navItems} />
             <CommunityCloudContent />
             <Footer links={footerItems} />

--- a/src/pages/community.js
+++ b/src/pages/community.js
@@ -1,4 +1,5 @@
 import * as React from "react";
+import '../pages/style.css';
 // Component imports
 import { Nav } from "../components/homepage/Navbar";
 import { Footer } from "../components/homepage/Footer";
@@ -45,12 +46,6 @@ const CommunityPage = () => {
 
     return (
         <main>
-            <style jsx global>{`
-      body {
-        margin: 0px;
-        padding: 0px;
-      }
-    `}</style>
             <Nav links={navItems} />
             <CommunityContent />
             <Footer links={footerItems} />

--- a/src/pages/docs-training.js
+++ b/src/pages/docs-training.js
@@ -1,4 +1,5 @@
 import * as React from "react";
+import '../pages/style.css';
 // Component imports
 import { Nav } from "../components/homepage/Navbar";
 import { Footer } from "../components/homepage/Footer";
@@ -45,12 +46,6 @@ const DocsTrainingPage = () => {
 
     return (
         <main>
-            <style jsx global>{`
-      body {
-        margin: 0px;
-        padding: 0px;
-      }
-    `}</style>
             <Nav links={navItems} />
             <DocTrainingContent />
             <Footer links={footerItems} />

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,5 @@
 import * as React from "react";
+import '../pages/style.css';
 // Component imports
 import { HomeContent } from "../components/homepage/HomePage";
 import { AboutFeatures } from "../components/homepage/About";
@@ -48,18 +49,12 @@ const IndexPage = () => {
 
   return (
     <main>
-      <style jsx global>{`
-      body {
-        margin: 0px;
-        padding: 0px;
-      }
-    `}</style>
       <Nav links={navItems} />
       <HomeContent />
       <AboutFeatures />
       <InterestedField />
       <FaqSimple />
-      <Footer links={footerItems}/>
+      <Footer links={footerItems} />
     </main>
   )
 }

--- a/src/pages/style.css
+++ b/src/pages/style.css
@@ -1,0 +1,4 @@
+body {
+    margin: 0px;
+    padding: 0px;
+}


### PR DESCRIPTION
## Description
This commit fixes props errors, fixed by changing component props to expected `propType`. Also fixing style-jsx errors by removing style-jsx and replacing it with simple CSS to give each page's body 0 margin and padding.

### Reference:
(Errors and dicussion risen from [Slack Convo](https://operatefirst.slack.com/archives/C01RF4SPNDD/p1652273307951929))
```
Warning: Failed prop type: Invalid prop `links` of type `array` supplied to `Nav`, expected `object`.
    at Nav (webpack-internal:///./src/components/homepage/Navbar.js:95:20)
    at CommunityPage```