### PR TITLE
Small padding fixes and removal of home buttons

### DIFF
--- a/src/components/homepage/About.js
+++ b/src/components/homepage/About.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { createStyles, Text, SimpleGrid, Container, Group, Title } from '@mantine/core';
+import { createStyles, Text, SimpleGrid, Container, Title } from '@mantine/core';
 import { Code, Cloud, BuildingCommunity } from 'tabler-icons-react';
 
 const useStyles = createStyles((theme) => ({

--- a/src/components/homepage/HomePage.js
+++ b/src/components/homepage/HomePage.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { createStyles, Overlay, Container, Title, Button, Image, Group, Center } from '@mantine/core';
+import { createStyles, Overlay, Container, Title, Button, Image, Group } from '@mantine/core';
 import { Link } from "gatsby"
 
 const useStyles = createStyles((theme) => ({
@@ -94,21 +94,17 @@ export function HomeContent() {
           height={"50%"}
         />
         <Title className={classes.title}>a concept to incorporate operational experience into software projects</Title>
-        {/* <Text className={classes.description} size="xl" mt="xl">
-        a concept to incorporate operational experience into software projects
-        </Text> */}
-
         <Group>
-          <Link to="/developer">
+          <Link to="/getting-started">
           <Button variant="gradient" size="lg" radius="xl" className={classes.control}>
-            Developer
+            Get Started
           </Button>
           </Link>
-          <Link to="/srepractices">
+          {/* <Link to="/srepractices">
           <Button variant="outline" color="white" size="lg" radius="xl" className={classes.control}>
             SRE Practices
           </Button>
-          </Link>
+          </Link> */}
         </Group>
       </Container>
     </div>

--- a/src/components/homepage/Interest.js
+++ b/src/components/homepage/Interest.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { createStyles, Group, Title, Text, TextInput, Button, Container, Center } from '@mantine/core';
-import { Code, Cloud, Book, ZoomQuestion, BrandSlack, Calendar, BrandGithub, Mail } from 'tabler-icons-react';
+import { createStyles, Group, Title, Text, Button, Container, Center } from '@mantine/core';
+import { Code, Cloud, Book, ZoomQuestion, BrandSlack, BrandGithub, Mail } from 'tabler-icons-react';
 
 const useStyles = createStyles((theme) => ({
     wrapper: {

--- a/src/components/nav-tabs/AboutPage.js
+++ b/src/components/nav-tabs/AboutPage.js
@@ -3,7 +3,7 @@ import React from 'react';
 
 export function AboutContent() {
     return (
-        <Container style={{ paddingBottom: 574 }}>
+        <Container style={{ paddingBottom: 200 }}>
             <Title order={2} my="md">Our Purpose</Title>
             <Text pb="sm">
               Open source software is widely available, but it faces an

--- a/src/components/nav-tabs/DocTraining.js
+++ b/src/components/nav-tabs/DocTraining.js
@@ -3,7 +3,7 @@ import React from 'react';
 
 export function DocTrainingContent() {
     return (
-        <Container pb={314}>
+        <Container pb={350}>
             <Title order={2} my="md">Operate First Documentation and Training</Title>
 
             <Text>Unified Operate First Glossary of Terms (link coming soon)</Text>

--- a/src/pages/community-cloud-workloads.js
+++ b/src/pages/community-cloud-workloads.js
@@ -2,8 +2,7 @@ import * as React from "react";
 // Component imports
 import { Nav } from "../components/homepage/Navbar";
 import { Footer } from "../components/homepage/Footer";
-import { Button, Container, Text, Title, Group, List } from '@mantine/core';
-import { Book, Cloud, Database } from 'tabler-icons-react';
+import { Container, Title} from '@mantine/core';
 
 const CommunityCloudPage = () => {
 

--- a/src/pages/community-cloud.js
+++ b/src/pages/community-cloud.js
@@ -4,7 +4,7 @@ import '../pages/style.css';
 import { Link } from "gatsby"
 import { Nav } from "../components/homepage/Navbar";
 import { Footer } from "../components/homepage/Footer";
-import { Button, Container, Text, Title, Group, List } from '@mantine/core';
+import { Button, Container, Text, Title, Group } from '@mantine/core';
 import { createStyles, Card, SimpleGrid, UnstyledButton, Anchor } from '@mantine/core';
 import { Book, Cloud } from 'tabler-icons-react';
 

--- a/src/pages/data-scientist.js
+++ b/src/pages/data-scientist.js
@@ -4,7 +4,7 @@ import '../pages/style.css';
 import { Nav } from "../components/homepage/Navbar";
 import { Footer } from "../components/homepage/Footer";
 import { Button, Container, Text, Title, Group, List } from '@mantine/core';
-import { Book, Cloud, Database } from 'tabler-icons-react';
+import { Book, Cloud } from 'tabler-icons-react';
 
 const CommunityCloudPage = () => {
 


### PR DESCRIPTION
## Description
This commit fixes some extra padding (whitespace) between content and the footer on some nav-pages

**Other changes:**
- Removed Developer and SRE buttons, replaced developer button with Get Started button with route to `getting-started`
- Removed some unused imports of mantine components